### PR TITLE
fix to handle method signatures with types like Map<String,dynamic>

### DIFF
--- a/lib/src/event_emitter.dart
+++ b/lib/src/event_emitter.dart
@@ -24,6 +24,7 @@ class EventEmitter {
     String arguments = func.runtimeType.toString().split(' => ')[0];
     if (arguments.length > 3) {
       String args = arguments.substring(1, arguments.length - 1);
+      args = args.replaceAll(RegExp("<(.*)>"), "");
       int argc = args.split(', ').length;
       switch (argc) {
         case 1:
@@ -60,6 +61,7 @@ class EventEmitter {
       var result;
       if (arguments.length > 3) {
         String args = arguments.substring(1, arguments.length - 1);
+        args = args.replaceAll(RegExp("<(.*)>"), "");
         int argc = args.split(', ').length;
         switch (argc) {
           case 1:
@@ -193,10 +195,10 @@ class EventEmitter {
    *
    * @return List<Function>
    */
-  List<dynamic> listeners(event){
+  List<dynamic> listeners(event) {
     var list = [];
-    list += this._events[event]?? [];
-    list += this._eventsOnce[event]?? [];
+    list += this._events[event] ?? [];
+    list += this._eventsOnce[event] ?? [];
     return list;
   }
 }

--- a/test/events_test.dart
+++ b/test/events_test.dart
@@ -1,10 +1,10 @@
 import 'dart:core';
-import 'package:events2/events2.dart';
 
+import '../lib/events2.dart';
 
 class MyClass extends EventEmitter {
-  MyClass(){}
-  void sendEvent(){
+  MyClass() {}
+  void sendEvent() {
     this.emit('event2', 'a', 'b', 3, 'd');
   }
 }


### PR DESCRIPTION
I went through the Dart_sip_ua example and added types.

EventEmitter isn't able to handle type information like Map<String,dynamic>.

It incorrectly determined the number of parameters from Func(Map<String,dynamic, String) as three in stead of two.

I've added some code to remove the information between < and > which fixes this problem.